### PR TITLE
Add Failing Test for Zero-Width Index Corrupting Links

### DIFF
--- a/t/05-zero-width-index.t
+++ b/t/05-zero-width-index.t
@@ -1,0 +1,11 @@
+use Test;
+use Pod::To::HTML;
+plan 1;
+
+=begin pod
+X<|behavior> L<http://www.doesnt.get.rendered.com>
+=end pod
+
+my $r = pod2html $=pod, :url({ $_ });
+ok $r ~~ m/'href="http://www.doesnt.get.rendered.com"'/;
+


### PR DESCRIPTION
Seems that when index with zero width is specified (`X<|pipe>`) that links are not rendered properly anymore. Most notably this affects http://docs.perl6.org/language/classtut.
Attached is just a failing test - been a journey to trace it down to here. 

P.S. Here is how MoarVM sees the pod:
```
=begin pod
X<|behavior> L<http://www.doesnt.get.rendered.com>
=end pod

Pod::Block::Named{:name("pod")}
  Pod::Block::Para

    Pod::FormattingCode{:type("X")}


    Pod::FormattingCode{:type("L")}
      http://www.doesnt.get.rendered.com
```
And here it is without zero width index
```
=begin pod
X<behavior> L<http://www.doesnt.get.rendered.com>
=end pod

Pod::Block::Named{:name("pod")}
  Pod::Block::Para

    Pod::FormattingCode{:type("X")}
      behavior

    Pod::FormattingCode{:type("L")}
      http://www.doesnt.get.rendered.com
```

Seems bug is in `::To::HTML`