### PR TITLE
Added trim to escape_id to handle extra whitespace.

### DIFF
--- a/lib/Pod/To/HTML.pm
+++ b/lib/Pod/To/HTML.pm
@@ -61,7 +61,7 @@ sub unescape_html(Str $str) returns Str {
 }
 
 sub escape_id ($id) {
-    $id.subst(/\s+/, '_', :g).subst('"', '&quot;', :g);
+    $id.trim.subst(/\s+/, '_', :g).subst('"', '&quot;', :g);
 }
 
 multi visit(Nil, |a) { 


### PR DESCRIPTION
#18 - When reading the POD file, =head* adds an extra space at the end. I added a trim in escape_id to fix it. 