### PR TITLE
Html block contains raw HTML code

### DIFF
--- a/lib/Pod/To/HTML.pm
+++ b/lib/Pod/To/HTML.pm
@@ -348,7 +348,7 @@ multi sub node2html(Pod::Block::Named $node) {
             return qq[<img src="$url" />];
         }
         when 'Xhtml' | 'Html' {
-            unescape_html node2rawhtml $node.contents
+            node2rawhtml $node.contents
         }
         default {
             if $node.name eq 'TITLE' {

--- a/lib/Pod/To/HTML.pm
+++ b/lib/Pod/To/HTML.pm
@@ -376,7 +376,7 @@ multi sub node2html(Pod::Block::Named $node) {
 }
 
 sub node2rawhtml(Positional $node) {
-    return $node.map({ $_.contents }).join
+    return $node.map({ node2rawtext $_}).join: "\n"
 }
 
 multi sub node2html(Pod::Block::Para $node) {


### PR DESCRIPTION
*Everything* within a Html block is assumed to be raw HTML.

Because of the implementation, pod6 syntax will be removed, only its raw text remind. That is, `C<code> -> code.`, `=item2 something -> something`

To write C<> within Html block, you can use `C&amp;&lt;&amp;&gt;`(because we unescape after generate from Html block, but why?)

To mix up pod6 and HTML, you can separate them into different blocks. See the example below:

```
=begin Html
111
=end Html

=begin code
  =begin code
  =end code
=end code

=begin Html
222
=end Html
```