### PR TITLE
Use of a debug environment variable.

### DIFF
--- a/lib/Pod/To/HTML.pm
+++ b/lib/Pod/To/HTML.pm
@@ -45,8 +45,8 @@ my @body;
 my @footnotes;
 my %crossrefs;
 
-
-constant DEBUG = %*ENV<P6DOC_DEBUG>;
+# see <https://docs.perl6.org/language/traps#Constants_are_Compile_Time>
+my constant DEBUG = %*ENV<P6DOC_DEBUG>;
 sub Debug(Callable $c) { $c() if DEBUG; }
 
 sub escape_html(Str $str) returns Str {

--- a/lib/Pod/To/HTML.pm
+++ b/lib/Pod/To/HTML.pm
@@ -45,8 +45,9 @@ my @body;
 my @footnotes;
 my %crossrefs;
 
- sub Debug(Callable $)  { }         # Disable debug code
-# sub Debug(Callable $c) { $c() }    # Enable debug code
+
+constant DEBUG = %*ENV<P6DOC_DEBUG>;
+sub Debug(Callable $c) { $c() if DEBUG; }
 
 sub escape_html(Str $str) returns Str {
     return $str unless $str ~~ /<[&<>"']>/;
@@ -143,7 +144,7 @@ sub assemble-list-items(:@content, :$node, *% ) {
 #| Converts a Pod tree to a HTML document.
 sub pod2html($pod, :&url = -> $url { $url }, :$head = '', :$header = '', :$footer = '', :$default-title,
   :$css-url = '//design.perl6.org/perl.css', :$lang = 'en',
-) is export returns Str {
+    ) is export returns Str {
     ($title, $subtitle, @meta, @indexes, @body, @footnotes) = ();
     #| Keep count of how many footnotes we've output.
     my Int $*done-notes = 0;

--- a/lib/Pod/To/HTML.pm
+++ b/lib/Pod/To/HTML.pm
@@ -46,8 +46,8 @@ my @footnotes;
 my %crossrefs;
 
 # see <https://docs.perl6.org/language/traps#Constants_are_Compile_Time>
-my constant DEBUG = %*ENV<P6DOC_DEBUG>;
-sub Debug(Callable $c) { $c() if DEBUG; }
+my  $DEBUG := %*ENV<P6DOC_DEBUG>;
+sub Debug(Callable $c) { $c() if $DEBUG; }
 
 sub escape_html(Str $str) returns Str {
     return $str unless $str ~~ /<[&<>"']>/;


### PR DESCRIPTION
Instead of defining a couple of methods with the same name 'Debug' to enable
or disable the debugging output, borrow the same P6DOC_DEBUG environment
variable.

Example of usage:
% export P6DOC_DEBUG=true
% perl6 --doc=HTML ~/your_pod_file.pod

Tested on:
% perl6 --version
This is Rakudo version 2017.11 built on MoarVM version 2017.11
implementing Perl 6.c.