### PR TITLE
Avoid errors in generated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-lib/.precomp/
+**/.precomp/

--- a/lib/Pod/To/HTML.pm
+++ b/lib/Pod/To/HTML.pm
@@ -438,11 +438,17 @@ multi sub node2html(Pod::Heading $node) {
 
     @indexes.push: Pair.new(key => $lvl, value => %escaped);
 
+    my $content;
+    if ( node2rawtext($node.contents) ~~ m{\<\/a\>} ) {
+      $content =  %escaped<html>;
+    } else {
+      $content = qq[<a class="u" href="#___top" title="go to top of document">]
+	~ %escaped<html>
+	~ qq[</a>];
+    }
+
     return sprintf('<h%d id="%s">', $lvl, %escaped<id>)
-                ~ qq[<a class="u" href="#___top" title="go to top of document">]
-                    ~ %escaped<html>
-                ~ qq[</a>]
-            ~ qq[</h{$lvl}>\n];
+                ~ $content ~ qq[</h{$lvl}>\n];
 }
 
 # FIXME

--- a/t/07-headings.t
+++ b/t/07-headings.t
@@ -30,7 +30,7 @@ plan 3;
 
 my $html = pod2html $=pod;
 
-put $html;
+#put $html;
 
 ($html ~~ m:g/ ('2.2.2') /);
 

--- a/t/07-headings.t
+++ b/t/07-headings.t
@@ -18,6 +18,8 @@ plan 3;
 
 =head2 Heading 2.2
 
+=head2 <a href="/routine/message#class_Exception">(Exception) method message</a>
+
 =head3 Heading 2.2.1
 
 =head3 X<Heading> 2.2.2
@@ -28,7 +30,7 @@ plan 3;
 
 my $html = pod2html $=pod;
 
-# put $html;
+put $html;
 
 ($html ~~ m:g/ ('2.2.2') /);
 


### PR DESCRIPTION
This seems to be the origin of the double links in perl6/doc#561 which for some weird reason is causing this kind of errors
```
List of broken links and other issues:
x:/routine/Bag	
  Line: 471
  Code: 501 Protocol scheme 'x' is not supported
 To do: Could not check this link: method not implemented or scheme not
	supported.
Fragments:
	class_Any                     	Line: 471
```
You can check the effect right there in file https://docs.perl6.org/type/X::Syntax::Number::RadixOutOfRange but there are literally tens of thousands in of that style:
```
<h2 id="(Exception)_method_message"><a class="u" href="#___top" title="go to top of document"><a href="/routine/message#class_Exception">(Exception) method message</a></a></h2>
```
This is probably caused by some error in htmlify.p6, but in fact I don't thin that those links to top are needed everywhere, even more so if there's a link already there. It does not change current API, it only behaves in some other way in some corner case. 