### PR TITLE
Modify tests

### DIFF
--- a/t/070-headings.t
+++ b/t/070-headings.t
@@ -18,7 +18,7 @@ plan 3;
 
 =head2 Heading 2.2
 
-=head2 <a href="/routine/message#class_Exception">(Exception) method message</a>
+=head2 L<(Exception) method message|/routine/message#class_Exception>
 
 =head3 Heading 2.2.1
 

--- a/t/075-defn.t
+++ b/t/075-defn.t
@@ -28,7 +28,7 @@ say $=pod[0].perl;
 
 my $html = pod2html($=pod[0]);
 
-say $html;
+#say $html;
 ok $html ~~ ms[[
 '<dl>'
 '<dt>MAD</dt>'


### PR DESCRIPTION
The canonical for adding links in pod6 is L<text|reference> not <a href="reference">text</a> 
So, test 070-headings.t is made canonical. 
test 075* has a 'say' statement that needs to be commented out.