### PR TITLE
add Pod::To::HTML class with stub render

### DIFF
--- a/lib/Pod/To/HTML.pm
+++ b/lib/Pod/To/HTML.pm
@@ -4,6 +4,13 @@ use URI::Escape;
 use Template::Mustache;
 use Pod::Load;
 
+# the Rakudo compiler expects there to be a render method with a Pod::To::<name> invocant
+## when --doc=name is used. Then the render method is called with a pod tree.
+## The following adds a Pod::To::HTML class and the method to call the subs in the module.
+class Pod::To::HTML {
+    method render( $pod ) { &render( $po ) }
+}
+
 #try require Term::ANSIColor <&colored>;
 #if &colored.defined {
     #&colored = -> $t, $c { $t };

--- a/lib/Pod/To/HTML.pm
+++ b/lib/Pod/To/HTML.pm
@@ -8,7 +8,7 @@ use Pod::Load;
 ## when --doc=name is used. Then the render method is called with a pod tree.
 ## The following adds a Pod::To::HTML class and the method to call the subs in the module.
 class Pod::To::HTML {
-    method render( $pod ) { &render( $po ) }
+    method render( $pod ) { &render( $pod ) }
 }
 
 #try require Term::ANSIColor <&colored>;


### PR DESCRIPTION
invocations of `perl6 --doc=HTML` were failing. This patch changes it.